### PR TITLE
refactor with bookmark source reader interface

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "(gdb) Attach",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/libbookmarksmodule/tests/xbel_reader_test",
+            "program": "${workspaceFolder}/build/libbookmarksmodule/tests/xbel_parser_test",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/build",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
         "string_view": "cpp",
         "typeinfo": "cpp",
         "qjsondocument": "cpp",
-        "qstandarditemmodel": "cpp"
+        "qstandarditemmodel": "cpp",
+        "qobject": "cpp"
     },
 }

--- a/libbookmarksmodule/CMakeLists.txt
+++ b/libbookmarksmodule/CMakeLists.txt
@@ -53,7 +53,8 @@ ADD_LIBRARY (
   include/libbookmarksmodule/xbel_parser.h
   include/libbookmarksmodule/data_types.h
   include/libbookmarksmodule/utils.h
-  include/libbookmarksmodule/environment_theme_facade.h)
+  include/libbookmarksmodule/environment_theme_facade.h
+  include/libbookmarksmodule/xbel_file_reader.h)
 QT5_USE_MODULES (${LIBNAME} Qml)
 SET_TARGET_PROPERTIES (
   ${LIBNAME}

--- a/libbookmarksmodule/CMakeLists.txt
+++ b/libbookmarksmodule/CMakeLists.txt
@@ -48,6 +48,7 @@ ADD_LIBRARY (
   src/bookmark_model_plugin.cpp
   src/xbel_parser.cpp
   src/utils.cpp
+  src/xbel_file_reader.cpp
   include/libbookmarksmodule/bookmark_model_plugin.h
   include/libbookmarksmodule/bookmarkmodel.h
   include/libbookmarksmodule/xbel_parser.h

--- a/libbookmarksmodule/CMakeLists.txt
+++ b/libbookmarksmodule/CMakeLists.txt
@@ -46,11 +46,11 @@ ADD_LIBRARY (
   ${LIBNAME} SHARED
   src/bookmarkmodel.cpp
   src/bookmark_model_plugin.cpp
-  src/xbel_reader.cpp
+  src/xbel_parser.cpp
   src/utils.cpp
   include/libbookmarksmodule/bookmark_model_plugin.h
   include/libbookmarksmodule/bookmarkmodel.h
-  include/libbookmarksmodule/xbel_reader.h
+  include/libbookmarksmodule/xbel_parser.h
   include/libbookmarksmodule/data_types.h
   include/libbookmarksmodule/utils.h
   include/libbookmarksmodule/environment_theme_facade.h)

--- a/libbookmarksmodule/include/libbookmarksmodule/bookmark_source_reader_interface.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/bookmark_source_reader_interface.h
@@ -1,0 +1,12 @@
+#ifndef BOOKMARK_SOURCE_READER_INTERFACE_H
+#define BOOKMARK_SOURCE_READER_INTERFACE_H
+
+#include <QtGui/QStandardItem>
+
+class BookmarkSourceReaderInterface {
+ public:
+  virtual ~BookmarkSourceReaderInterface() = default;
+  virtual void read(QStandardItem* root_item) = 0;
+};
+
+#endif // BOOKMARK_SOURCE_READER_INTERFACE_H

--- a/libbookmarksmodule/include/libbookmarksmodule/xbel_file_reader.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xbel_file_reader.h
@@ -10,9 +10,11 @@ class XbelFileReader : public XmlBookmarkReaderInterface {
   XbelFileReader(XmlParserInterface& xml_parser,const BookmarkSource& bookmark_source);
   virtual ~XbelFileReader() = default;
 
-  void setFilePath(const QString& file_path);
+  bool setFilePath(const QString& file_path);
 
   virtual void read(QStandardItem* root_item) final;
+  private:
+  QString m_file_path;
 };
 
 #endif  // XBEL_FILE_READER_H

--- a/libbookmarksmodule/include/libbookmarksmodule/xbel_file_reader.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xbel_file_reader.h
@@ -1,0 +1,18 @@
+#ifndef XBEL_FILE_READER_H
+#define XBEL_FILE_READER_H
+#include <libbookmarksmodule/bookmark_source_reader_interface.h>
+#include <libbookmarksmodule/data_types.h>
+
+#include <QtGui/QStandardItem>
+
+class XbelFileReader : public BookmarkSourceReaderInterface {
+ public:
+  explicit XbelFileReader(const BookmarkSource& bookmark_source);
+  virtual ~XbelFileReader() = default;
+
+  void setFilePath(const QString& file_path);
+
+  virtual void read(QStandardItem* root_item) final;
+};
+
+#endif  // XBEL_FILE_READER_H

--- a/libbookmarksmodule/include/libbookmarksmodule/xbel_file_reader.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xbel_file_reader.h
@@ -1,13 +1,13 @@
 #ifndef XBEL_FILE_READER_H
 #define XBEL_FILE_READER_H
-#include <libbookmarksmodule/bookmark_source_reader_interface.h>
+#include <libbookmarksmodule/xml_bookmark_reader_interface.h>
 #include <libbookmarksmodule/data_types.h>
 
 #include <QtGui/QStandardItem>
 
-class XbelFileReader : public BookmarkSourceReaderInterface {
+class XbelFileReader : public XmlBookmarkReaderInterface {
  public:
-  explicit XbelFileReader(const BookmarkSource& bookmark_source);
+  XbelFileReader(XmlParserInterface& xml_parser,const BookmarkSource& bookmark_source);
   virtual ~XbelFileReader() = default;
 
   void setFilePath(const QString& file_path);

--- a/libbookmarksmodule/include/libbookmarksmodule/xbel_parser.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xbel_parser.h
@@ -1,16 +1,18 @@
 #ifndef XBEL_PARSER_H
 #define XBEL_PARSER_H
 #include <libbookmarksmodule/bookmarkmodel.h>
+#include <libbookmarksmodule/xml_parser_interface.h>
 #include <libbookmarksmodule/environment_theme_facade.h>
 
 #include <QtCore/QXmlStreamReader>
 #include <QtGui/QStandardItemModel>
 #include <memory>
 
-class XbelParser {
+class XbelParser :public XmlParserInterface {
  public:
   explicit XbelParser(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade);
-  void read(QXmlStreamReader& xml_stream, QStandardItem* parent);
+  virtual ~XbelParser() = default;
+  virtual void read(QXmlStreamReader& xml_stream, QStandardItem* parent) final;
  private:
   void readXbelTitle(QXmlStreamReader& xml_stream, QStandardItem* parent);
   void readXbelInfo(QXmlStreamReader& xml_stream, QStandardItem* parent);

--- a/libbookmarksmodule/include/libbookmarksmodule/xbel_parser.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xbel_parser.h
@@ -1,5 +1,5 @@
-#ifndef XBEL_READER_H
-#define XBEL_READER_H
+#ifndef XBEL_PARSER_H
+#define XBEL_PARSER_H
 #include <libbookmarksmodule/bookmarkmodel.h>
 #include <libbookmarksmodule/environment_theme_facade.h>
 
@@ -7,9 +7,9 @@
 #include <QtGui/QStandardItemModel>
 #include <memory>
 
-class XbelReader {
+class XbelParser {
  public:
-  explicit XbelReader(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade);
+  explicit XbelParser(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade);
   void readXbelTitle(QXmlStreamReader& xml_stream, QStandardItem* parent);
   void readXbelInfo(QXmlStreamReader& xml_stream, QStandardItem* parent);
   void readXbelIcon(QXmlStreamReader& xml_stream, QStandardItem* parent);
@@ -22,4 +22,4 @@ class XbelReader {
   const AbstractEnvironmentThemeFacade& m_theme_facade;
 };
 
-#endif  // XBEL_READER_H
+#endif  // xbel_parser_H

--- a/libbookmarksmodule/include/libbookmarksmodule/xbel_parser.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xbel_parser.h
@@ -10,14 +10,13 @@
 class XbelParser {
  public:
   explicit XbelParser(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade);
+  void read(QXmlStreamReader& xml_stream, QStandardItem* parent);
+ private:
   void readXbelTitle(QXmlStreamReader& xml_stream, QStandardItem* parent);
   void readXbelInfo(QXmlStreamReader& xml_stream, QStandardItem* parent);
   void readXbelIcon(QXmlStreamReader& xml_stream, QStandardItem* parent);
   void readXbelBookmark(QXmlStreamReader& xml_stream, QStandardItem* parent);
   void readXbelFolder(QXmlStreamReader& xml_stream, QStandardItem* parent);
-  void read(QXmlStreamReader& xml_stream, QStandardItem* parent);
-
- private:
   BookmarkSource m_bookmark_source;
   const AbstractEnvironmentThemeFacade& m_theme_facade;
 };

--- a/libbookmarksmodule/include/libbookmarksmodule/xml_bookmark_reader_interface.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xml_bookmark_reader_interface.h
@@ -1,0 +1,16 @@
+#ifndef XML_BOOKMARK_READER_INTERFACE_H
+#define XML_BOOKMARK_READER_INTERFACE_H
+
+#include <libbookmarksmodule/bookmark_source_reader_interface.h>
+#include <libbookmarksmodule/xml_parser_interface.h>
+
+class XmlBookmarkReaderInterface : public BookmarkSourceReaderInterface {
+ public:
+    explicit XmlBookmarkReaderInterface(XmlParserInterface& xml_parser):m_xml_parser{xml_parser}{}
+  virtual ~XmlBookmarkReaderInterface() = default;
+  protected:
+    XmlParserInterface& m_xml_parser;
+};
+
+
+#endif //XML_BOOKMARK_READER_INTERFACE_H

--- a/libbookmarksmodule/include/libbookmarksmodule/xml_parser_interface.h
+++ b/libbookmarksmodule/include/libbookmarksmodule/xml_parser_interface.h
@@ -1,0 +1,15 @@
+#ifndef XML_PARSER_INTERFACE_H
+#define XML_PARSER_INTERFACE_H
+#include <QtCore/QXmlStreamReader>
+#include <QtGui/QStandardItemModel>
+#include <libbookmarksmodule/environment_theme_facade.h>
+
+class XmlParserInterface {
+ public:
+  XmlParserInterface(const BookmarkSource , const AbstractEnvironmentThemeFacade& ){}
+  virtual ~XmlParserInterface() = default;
+  virtual void read(QXmlStreamReader& xml_stream, QStandardItem* parent)=0;
+};
+
+
+#endif //XML_PARSER_INTERFACE_H

--- a/libbookmarksmodule/src/xbel_file_reader.cpp
+++ b/libbookmarksmodule/src/xbel_file_reader.cpp
@@ -1,0 +1,1 @@
+#include <libbookmarksmodule/xbel_file_reader.h>

--- a/libbookmarksmodule/src/xbel_file_reader.cpp
+++ b/libbookmarksmodule/src/xbel_file_reader.cpp
@@ -1,12 +1,45 @@
-#include <libbookmarksmodule/xbel_file_reader.h>
-
-
+    #include <QtCore/QFileInfo>
+    #include <QtCore/QFile>
+    #include <libbookmarksmodule/xbel_file_reader.h>
+    #include <QDebug>
+    #include <QLoggingCategory>
+#include <QtCore/QXmlStreamReader>
+    Q_LOGGING_CATEGORY(logger, "XbelFileReader")
 XbelFileReader::XbelFileReader(XmlParserInterface& xml_parser,const BookmarkSource& bookmark_source)
     : XmlBookmarkReaderInterface(xml_parser)
 {
 }
 
+bool XbelFileReader::setFilePath(const QString& file_path)
+{
+    QFileInfo fileInfo(file_path);
+    if (fileInfo.exists() ) {
+        return true;
+    } else {
+        qCWarning(logger) << "File does not exist: "<<file_path;
+        return false;
+    }
+     if (fileInfo.isReadable()) {
+        return true;
+    } else {
+        qCWarning(logger) << "Not a file: "<<file_path;
+        return false;
+    }
+    if ( fileInfo.isReadable()) {
+        return true;
+    } else {
+        qCWarning(logger) << "File not readable: "<<file_path;
+        return false;
+    }
+    m_file_path = file_path;
+    return false;
+}
+
 void XbelFileReader::read(QStandardItem* root_item)
 {
-    return;
+    QFile xml_file(m_file_path);
+    xml_file.open(QIODevice::ReadOnly);
+    QXmlStreamReader xml_stream;
+    xml_stream.setDevice(&xml_file);
+    m_xml_parser.read(xml_stream, root_item);
 }

--- a/libbookmarksmodule/src/xbel_file_reader.cpp
+++ b/libbookmarksmodule/src/xbel_file_reader.cpp
@@ -1,1 +1,12 @@
 #include <libbookmarksmodule/xbel_file_reader.h>
+
+
+XbelFileReader::XbelFileReader(XmlParserInterface& xml_parser,const BookmarkSource& bookmark_source)
+    : XmlBookmarkReaderInterface(xml_parser)
+{
+}
+
+void XbelFileReader::read(QStandardItem* root_item)
+{
+    return;
+}

--- a/libbookmarksmodule/src/xbel_parser.cpp
+++ b/libbookmarksmodule/src/xbel_parser.cpp
@@ -1,6 +1,6 @@
 #include <libbookmarksmodule/data_types.h>
 #include <libbookmarksmodule/utils.h>
-#include <libbookmarksmodule/xbel_reader.h>
+#include <libbookmarksmodule/xbel_parser.h>
 
 #include <QtCore/QXmlStreamReader>
 #include <QtGui/QStandardItemModel>
@@ -9,20 +9,20 @@ bool isFolder(const QStandardItem* item) {
   return item->data(BookmarkRoles::IsFolderRole).toBool();
 }
 
-XbelReader::XbelReader(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade)
+XbelParser::XbelParser(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade)
     : m_bookmark_source(bookmark_source), m_theme_facade{theme_facade} {
 }
 
-void XbelReader::readXbelTitle(QXmlStreamReader& xml_stream, QStandardItem* parent) {
+void XbelParser::readXbelTitle(QXmlStreamReader& xml_stream, QStandardItem* parent) {
   parent->setText(xml_stream.readElementText());
 }
 
-void XbelReader::readXbelIcon(QXmlStreamReader& xml_stream, QStandardItem* parent) {
+void XbelParser::readXbelIcon(QXmlStreamReader& xml_stream, QStandardItem* parent) {
   const auto iconname = xml_stream.attributes().value("name").toString();
   const auto customortheme = m_theme_facade.getCustomOrThemeIconPath(isFolder(parent), m_bookmark_source, iconname);
   parent->setData(customortheme, Qt::UserRole);
 }
-void XbelReader::readXbelInfo(QXmlStreamReader& xml_stream, QStandardItem* parent) {
+void XbelParser::readXbelInfo(QXmlStreamReader& xml_stream, QStandardItem* parent) {
   while (xml_stream.readNextStartElement()) {
     if (xml_stream.name() == "metadata") {
       while (xml_stream.readNextStartElement()) {
@@ -34,7 +34,7 @@ void XbelReader::readXbelInfo(QXmlStreamReader& xml_stream, QStandardItem* paren
   }
 }
 
-void XbelReader::readXbelBookmark(QXmlStreamReader& xml_stream, QStandardItem* parent) {
+void XbelParser::readXbelBookmark(QXmlStreamReader& xml_stream, QStandardItem* parent) {
   QStandardItem* bookmark=new QStandardItem();
   bookmark->setData(false, BookmarkRoles::IsFolderRole);
   bookmark->setToolTip(xml_stream.attributes().value("href").toString());
@@ -43,7 +43,7 @@ void XbelReader::readXbelBookmark(QXmlStreamReader& xml_stream, QStandardItem* p
   read(xml_stream, bookmark);
 }
 
-void XbelReader::readXbelFolder(QXmlStreamReader& xml_stream, QStandardItem* parent) {
+void XbelParser::readXbelFolder(QXmlStreamReader& xml_stream, QStandardItem* parent) {
   QStandardItem* folder=new QStandardItem();
 
   folder->setData(true, BookmarkRoles::IsFolderRole);
@@ -51,7 +51,7 @@ void XbelReader::readXbelFolder(QXmlStreamReader& xml_stream, QStandardItem* par
   read(xml_stream, folder);
 }
 
-void XbelReader::read(QXmlStreamReader& xml_stream, QStandardItem* parent) {
+void XbelParser::read(QXmlStreamReader& xml_stream, QStandardItem* parent) {
   while(!xml_stream.atEnd()&& !xml_stream.hasError())
   {
     QXmlStreamReader::TokenType token = xml_stream.readNext();

--- a/libbookmarksmodule/src/xbel_parser.cpp
+++ b/libbookmarksmodule/src/xbel_parser.cpp
@@ -9,8 +9,30 @@ bool isFolder(const QStandardItem* item) {
   return item->data(BookmarkRoles::IsFolderRole).toBool();
 }
 
+
 XbelParser::XbelParser(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade)
-    : m_bookmark_source(bookmark_source), m_theme_facade{theme_facade} {
+    :  XmlParserInterface(bookmark_source, theme_facade),m_bookmark_source(bookmark_source), m_theme_facade{theme_facade} {
+}
+
+void XbelParser::read(QXmlStreamReader& xml_stream, QStandardItem* parent) {
+  while(!xml_stream.atEnd()&& !xml_stream.hasError())
+  {
+    QXmlStreamReader::TokenType token = xml_stream.readNext();
+        if (token == QXmlStreamReader::StartDocument) {
+            continue;
+        }
+        if (token == QXmlStreamReader::StartElement) {
+            if (xml_stream.name() == "bookmark") {
+              readXbelBookmark(xml_stream, parent);
+            } else if (xml_stream.name() == "folder") {
+              readXbelFolder(xml_stream, parent);
+            } else if (xml_stream.name() == "title") {
+              readXbelTitle(xml_stream, parent);
+            }
+        } else if (xml_stream.qualifiedName() == "bookmark:icon") {
+              readXbelIcon(xml_stream, parent);
+        }
+    }
 }
 
 void XbelParser::readXbelTitle(QXmlStreamReader& xml_stream, QStandardItem* parent) {
@@ -49,25 +71,4 @@ void XbelParser::readXbelFolder(QXmlStreamReader& xml_stream, QStandardItem* par
   folder->setData(true, BookmarkRoles::IsFolderRole);
   parent->setChild(parent->rowCount(),0,folder);
   read(xml_stream, folder);
-}
-
-void XbelParser::read(QXmlStreamReader& xml_stream, QStandardItem* parent) {
-  while(!xml_stream.atEnd()&& !xml_stream.hasError())
-  {
-    QXmlStreamReader::TokenType token = xml_stream.readNext();
-        if (token == QXmlStreamReader::StartDocument) {
-            continue;
-        }
-        if (token == QXmlStreamReader::StartElement) {
-            if (xml_stream.name() == "bookmark") {
-              readXbelBookmark(xml_stream, parent);
-            } else if (xml_stream.name() == "folder") {
-              readXbelFolder(xml_stream, parent);
-            } else if (xml_stream.name() == "title") {
-              readXbelTitle(xml_stream, parent);
-            }
-        } else if (xml_stream.qualifiedName() == "bookmark:icon") {
-              readXbelIcon(xml_stream, parent);
-        }
-    }
 }

--- a/libbookmarksmodule/tests/CMakeLists.txt
+++ b/libbookmarksmodule/tests/CMakeLists.txt
@@ -39,8 +39,8 @@ TARGET_INCLUDE_DIRECTORIES (bookmarksmodule_chrome_test
                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 TARGET_LINK_LIBRARIES (bookmarksmodule_chrome_test PRIVATE ${LIBNAME} Qt5::Test)
 
-ADD_EXECUTABLE (xbel_reader_test xbel_reader_test.cpp)
-ADD_TEST (xbel_reader_test xbel_reader_test)
-TARGET_INCLUDE_DIRECTORIES (xbel_reader_test
+ADD_EXECUTABLE (xbel_parser_test xbel_parser_test.cpp)
+ADD_TEST (xbel_parser_test xbel_parser_test)
+TARGET_INCLUDE_DIRECTORIES (xbel_parser_test
                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-TARGET_LINK_LIBRARIES (xbel_reader_test PRIVATE ${LIBNAME} Qt5::Test)
+TARGET_LINK_LIBRARIES (xbel_parser_test PRIVATE ${LIBNAME} Qt5::Test)

--- a/libbookmarksmodule/tests/CMakeLists.txt
+++ b/libbookmarksmodule/tests/CMakeLists.txt
@@ -50,3 +50,5 @@ ADD_TEST (xbel_file_reader_test xbel_file_reader_test)
 TARGET_INCLUDE_DIRECTORIES (xbel_file_reader_test
                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 TARGET_LINK_LIBRARIES (xbel_file_reader_test PRIVATE ${LIBNAME} Qt5::Test)
+
+FILE (WRITE ${CMAKE_CURRENT_BINARY_DIR}/existing_file "Some content")

--- a/libbookmarksmodule/tests/CMakeLists.txt
+++ b/libbookmarksmodule/tests/CMakeLists.txt
@@ -44,3 +44,9 @@ ADD_TEST (xbel_parser_test xbel_parser_test)
 TARGET_INCLUDE_DIRECTORIES (xbel_parser_test
                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 TARGET_LINK_LIBRARIES (xbel_parser_test PRIVATE ${LIBNAME} Qt5::Test)
+
+ADD_EXECUTABLE (xbel_file_reader_test xbel_file_reader_test.cpp)
+ADD_TEST (xbel_file_reader_test xbel_file_reader_test)
+TARGET_INCLUDE_DIRECTORIES (xbel_file_reader_test
+                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+TARGET_LINK_LIBRARIES (xbel_file_reader_test PRIVATE ${LIBNAME} Qt5::Test)

--- a/libbookmarksmodule/tests/mocks.h
+++ b/libbookmarksmodule/tests/mocks.h
@@ -1,6 +1,7 @@
 #ifndef MOCKS_H
 #define MOCKS_H
 #include <libbookmarksmodule/environment_theme_facade.h>
+#include <libbookmarksmodule/xml_parser_interface.h>
 
 class MockEnvironmentThemeFacade : public AbstractEnvironmentThemeFacade {
  public:
@@ -14,5 +15,16 @@ class MockEnvironmentThemeFacade : public AbstractEnvironmentThemeFacade {
     return "mocked_getCustomOrThemeIconPath";
   }
 };
+
+class MockXbelParserInterface : public XmlParserInterface {
+ public:
+  explicit MockXbelParserInterface(const BookmarkSource bookmark_source, const AbstractEnvironmentThemeFacade& theme_facade)
+      : XmlParserInterface(bookmark_source, theme_facade) {}
+  ~MockXbelParserInterface() = default;
+  virtual void read(QXmlStreamReader& xml_stream, QStandardItem* parent) final {
+    return;
+  }
+};
+
 
 #endif  // MOCKS_H

--- a/libbookmarksmodule/tests/mocks.h
+++ b/libbookmarksmodule/tests/mocks.h
@@ -22,8 +22,10 @@ class MockXbelParserInterface : public XmlParserInterface {
       : XmlParserInterface(bookmark_source, theme_facade) {}
   ~MockXbelParserInterface() = default;
   virtual void read(QXmlStreamReader& xml_stream, QStandardItem* parent) final {
+    readCallCount++;
     return;
   }
+  int readCallCount{};
 };
 
 

--- a/libbookmarksmodule/tests/xbel_file_reader_test.cpp
+++ b/libbookmarksmodule/tests/xbel_file_reader_test.cpp
@@ -8,10 +8,34 @@ void XbelFileReaderTest::test_constructor()
     MockEnvironmentThemeFacade theme_facade;
     MockXbelParserInterface xml_parser(BookmarkSource::Konqueror,theme_facade);
     XbelFileReader reader(xml_parser, BookmarkSource::Konqueror);
-
-    QVERIFY(false);
 }
 
+void XbelFileReaderTest::test_set_file_path_of_non_existing_file()
+{
+    MockEnvironmentThemeFacade theme_facade;
+    MockXbelParserInterface xml_parser(BookmarkSource::Konqueror,theme_facade);
+    XbelFileReader reader(xml_parser, BookmarkSource::Konqueror);
+    QVERIFY2(!reader.setFilePath({"non_existing_file"}), "setFilePath() failed to return true for non existing file");
+}
 
+void XbelFileReaderTest::test_set_file_path_of_existing_file()
+{
+    MockEnvironmentThemeFacade theme_facade;
+    MockXbelParserInterface xml_parser(BookmarkSource::Konqueror,theme_facade);
+    XbelFileReader reader(xml_parser, BookmarkSource::Konqueror);
+    QVERIFY2(reader.setFilePath({"existing_file"}), "setFilePath() failed to return true for existing file");
+}
+
+void XbelFileReaderTest::test_read_calls_read_on_xml_parser()
+{
+    MockEnvironmentThemeFacade theme_facade;
+    MockXbelParserInterface xml_parser(BookmarkSource::Konqueror,theme_facade);
+    XbelFileReader reader(xml_parser, BookmarkSource::Konqueror);
+    QStandardItem root_item;
+    reader.setFilePath({"existing_file"});
+    reader.read(&root_item);
+
+    QVERIFY2(xml_parser.readCallCount == 1, "read() failed to call read on xml_parser");
+}
 QTEST_GUILESS_MAIN(XbelFileReaderTest)
 #include "moc_xbel_file_reader_test.cpp"

--- a/libbookmarksmodule/tests/xbel_file_reader_test.cpp
+++ b/libbookmarksmodule/tests/xbel_file_reader_test.cpp
@@ -1,0 +1,17 @@
+#include <libbookmarksmodule/xbel_file_reader.h>
+#include <libbookmarksmodule/data_types.h>
+#include <xbel_file_reader_test.h>
+#include <mocks.h>
+
+void XbelFileReaderTest::test_constructor()
+{
+    MockEnvironmentThemeFacade theme_facade;
+    MockXbelParserInterface xml_parser(BookmarkSource::Konqueror,theme_facade);
+    XbelFileReader reader(xml_parser, BookmarkSource::Konqueror);
+
+    QVERIFY(false);
+}
+
+
+QTEST_GUILESS_MAIN(XbelFileReaderTest)
+#include "moc_xbel_file_reader_test.cpp"

--- a/libbookmarksmodule/tests/xbel_file_reader_test.h
+++ b/libbookmarksmodule/tests/xbel_file_reader_test.h
@@ -7,8 +7,12 @@
 
 class XbelFileReaderTest : public QObject {
   Q_OBJECT
+
  private Q_SLOTS:
   void test_constructor();
+  void test_set_file_path_of_non_existing_file();
+  void test_set_file_path_of_existing_file();
+  void test_read_calls_read_on_xml_parser();
 };
 
 #endif  // XBEL_FILE_READER_TEST_H

--- a/libbookmarksmodule/tests/xbel_file_reader_test.h
+++ b/libbookmarksmodule/tests/xbel_file_reader_test.h
@@ -1,0 +1,14 @@
+#ifndef XBEL_FILE_READER_TEST_H
+#define XBEL_FILE_READER_TEST_H
+
+#include <QtCore/QObject>
+#include <QtTest/QTest>
+
+
+class XbelFileReaderTest : public QObject {
+  Q_OBJECT
+ private Q_SLOTS:
+  void test_constructor();
+};
+
+#endif  // XBEL_FILE_READER_TEST_H

--- a/libbookmarksmodule/tests/xbel_parser_test.cpp
+++ b/libbookmarksmodule/tests/xbel_parser_test.cpp
@@ -1,7 +1,7 @@
 #include <libbookmarksmodule/data_types.h>
-#include <libbookmarksmodule/xbel_reader.h>
+#include <libbookmarksmodule/xbel_parser.h>
 #include <mocks.h>
-#include <xbel_reader_test.h>
+#include <xbel_parser_test.h>
 
 #include <QtCore/QXmlStreamReader>
 #include <QtGui/QStandardItemModel>
@@ -123,7 +123,7 @@ void affect_expected_nested_folder_and_side_by_side(QStandardItem* item)
   affect_expected_second_empty_folder(item);
 }
 
-void XbelReaderTest::test_read_xbel_bookmark() {
+void XbelParserTest::test_read_xbel_bookmark() {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<bookmark href="http://www.url.com">
 <title>bookmark 1</title>
@@ -137,7 +137,7 @@ void XbelReaderTest::test_read_xbel_bookmark() {
   fixture_test_xbel(xml_stream, affect_expected_bookmark_item, "<bookmark>");
 }
 
-void XbelReaderTest::test_empty_folder() {
+void XbelParserTest::test_empty_folder() {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<folder folded="no">
    <title>Folder One</title>
@@ -146,7 +146,7 @@ void XbelReaderTest::test_empty_folder() {
   fixture_test_xbel(xml_stream, affect_expected_empty_folder, "Empty Folder");
 }
 
-void XbelReaderTest::test_folder_with_one_bookmark()
+void XbelParserTest::test_folder_with_one_bookmark()
 {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<folder folded="no">
@@ -163,7 +163,7 @@ void XbelReaderTest::test_folder_with_one_bookmark()
   fixture_test_xbel(xml_stream,affect_expected_folder_with_one_bookmark,"Folder with one bookmark");
 }
 
-void XbelReaderTest::test_folder_with_two_bookmark()
+void XbelParserTest::test_folder_with_two_bookmark()
 {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<folder folded="no">
@@ -188,21 +188,21 @@ void XbelReaderTest::test_folder_with_two_bookmark()
   fixture_test_xbel(xml_stream,affect_expected_folder_with_two_bookmark,"Folder with one bookmark");
 }
 
-void XbelReaderTest::test_read_xbel_icon() {
+void XbelParserTest::test_read_xbel_icon() {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<bookmark:icon name="www"/>)");
 
   fixture_test_xbel(xml_stream, affect_expected_icon, "<bookmark:icon name>");
 }
 
-void XbelReaderTest::test_read_xbel_title() {
+void XbelParserTest::test_read_xbel_title() {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<title>bookmark 1</title>)");
 
   fixture_test_xbel(xml_stream, affect_expected_title, "<title>");
 }
 
-void XbelReaderTest::test_two_folder_side_by_side()
+void XbelParserTest::test_two_folder_side_by_side()
 {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<folder folded="no">
@@ -214,7 +214,7 @@ void XbelReaderTest::test_two_folder_side_by_side()
   fixture_test_xbel(xml_stream,affect_expected_two_folder_side_by_side,"Two folder side by side");
 }
 
-void XbelReaderTest::test_nested_folder()
+void XbelParserTest::test_nested_folder()
 {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<folder folded="no">
@@ -226,7 +226,7 @@ void XbelReaderTest::test_nested_folder()
   fixture_test_xbel(xml_stream,affect_expected_nested_folder,"Nested folder");
 }
 
-void XbelReaderTest::test_nested_folder_and_side_by_side()
+void XbelParserTest::test_nested_folder_and_side_by_side()
 {
   QXmlStreamReader xml_stream;
   xml_stream.addData(R"(<folder folded="no">
@@ -241,13 +241,13 @@ void XbelReaderTest::test_nested_folder_and_side_by_side()
   fixture_test_xbel(xml_stream,affect_expected_nested_folder_and_side_by_side,"Nested folder and side by side");
 }
 
-void XbelReaderTest::fixture_test_xbel(QXmlStreamReader& xml_stream,
+void XbelParserTest::fixture_test_xbel(QXmlStreamReader& xml_stream,
                                        std::function<void(QStandardItem*)> expected_builder,
                                        const QString& message) {
   QStandardItem* parent=new QStandardItem();
   MockEnvironmentThemeFacade facade{};
-  XbelReader xbel_reader{BookmarkSource::Konqueror, facade};
-  xbel_reader.read(xml_stream, parent);
+  XbelParser xbel_parser{BookmarkSource::Konqueror, facade};
+  xbel_parser.read(xml_stream, parent);
 
   QStandardItem* expected= new QStandardItem();
   expected_builder(expected);
@@ -255,5 +255,5 @@ void XbelReaderTest::fixture_test_xbel(QXmlStreamReader& xml_stream,
   assert_equal(parent, expected, message);
 }
 
-QTEST_GUILESS_MAIN(XbelReaderTest)
-#include "moc_xbel_reader_test.cpp"
+QTEST_GUILESS_MAIN(XbelParserTest)
+#include "moc_xbel_parser_test.cpp"

--- a/libbookmarksmodule/tests/xbel_parser_test.h
+++ b/libbookmarksmodule/tests/xbel_parser_test.h
@@ -1,5 +1,5 @@
-#ifndef XBEL_READER_TEST_H
-#define XBEL_READER_TEST_H
+#ifndef xbel_parser_TEST_H
+#define xbel_parser_TEST_H
 
 #include <QtCore/QObject>
 #include <QtTest/QTest>
@@ -20,7 +20,7 @@ void affect_expected_nested_folder(QStandardItem* item);
 void affect_expected_nested_folder_and_side_by_side(QStandardItem* item);
 
 
-class XbelReaderTest : public QObject {
+class XbelParserTest : public QObject {
   Q_OBJECT
  private Q_SLOTS:
   void test_read_xbel_title();
@@ -37,4 +37,4 @@ class XbelReaderTest : public QObject {
   void fixture_test_xbel(QXmlStreamReader& xml_stream, std::function<void(QStandardItem*)> expected_builder, const QString& message);
 };
 
-#endif  // XBEL_READER_TEST_H
+#endif  // xbel_parser_TEST_H


### PR DESCRIPTION
- Add some config for debugging and cmake integratonion in VScode and devcontainer
- Extract functions from bookmarkmodel to xbel_reader
- Move tests to QTEST_GUILESS_MAIN
- Refactor tests
- Reorder .pre commit
- Implement parsing of folder with mutliple bookmarks
- Refactor test with pointers
- Fix implementation of one folder with mutliple bookmarks
- Add test for two folder side by side
- Implement Nested folder and side by side
- Clean tests
- rename xbel_reader to xbel_parser
- Move xbel_parser subfunctions to private
- Refactor with xml_bookmark_reader_interface and xml_parser_interface
- Update settings.json
- Implementation of xbel_file_reader_interface
